### PR TITLE
Fixed dependency problems.

### DIFF
--- a/hello/BUILD.bazel
+++ b/hello/BUILD.bazel
@@ -6,7 +6,7 @@ cc_library(
     hdrs = ["hello.h"],
     deps = [
         "@com_google_absl//absl/strings",
-        "@com_google_differential_privacy//cc/base:statusor",
+        "@com_google_cc_differential_privacy//base:statusor",
     ],
 )
 

--- a/hello/WORKSPACE
+++ b/hello/WORKSPACE
@@ -31,10 +31,16 @@ http_archive(
 )
 
 # Repro
-git_repository(
+http_archive(
     name = "com_google_differential_privacy",
-    commit = "9923ad4ee1b84a7002085e50345fcc05f2b21bcb",
-    remote = "https://github.com/google/differential-privacy.git",
+    urls = ["https://github.com/google/differential-privacy/archive/main.zip"],
+    strip_prefix = "differential-privacy-main",
+) 
+
+http_archive(
+    name = "com_google_cc_differential_privacy",
+    urls = ["https://github.com/google/differential-privacy/archive/main.zip"],
+    strip_prefix = "differential-privacy-main/cc",
 )
 
 load("@com_google_differential_privacy//:differential_privacy_deps.bzl", "differential_privacy_deps")


### PR DESCRIPTION
Modified WORKSPACE and BUILD.bzl to correctly depend on the C++ differential privacy library. Much as in the tink example code, we need to explicitly depend on both the cc workspace and the base workspace. The key here is the use of strip_prefix, which ensures that the correct workspace file ends up at the root for each http_archive rule.